### PR TITLE
Default Agena 8096C part to 8096C config

### DIFF
--- a/GameData/ROEngines/PartConfigs/Agena_SSTU.cfg
+++ b/GameData/ROEngines/PartConfigs/Agena_SSTU.cfg
@@ -440,7 +440,7 @@ PART
 	@title = XLR81 Agena Model 8096C Vacuum Engine
 	@MODULE[ModuleEngineConfigs] 
 	{
-		@configuration = Model8096L
+		@configuration = Model8096C
 		!CONFIG[Model117] {}
 		!CONFIG[XLR81-BA-3] {}
 		!CONFIG[XLR81-BA-5] {}


### PR DESCRIPTION
Because that's the config that unlocks at the same time as the part in RP-1.